### PR TITLE
failure example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Ref: [tonic/examples/helloworld-tutorial.md at master · hyperium/tonic](https://github.com/hyperium/tonic/blob/master/examples/helloworld-tutorial.md)
 
+# Failure
+
+```shell
+❯ grpcurl -plaintext -import-path src/proto -proto hello.proto -d '{
+  "id": 140
+}' localhost:50051 vector.VectorService/GetVector
+Error invoking method "vector.VectorService/GetVector": target server does not expose service "vector.VectorService"
+```
+
 # SetUp
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use rand::Rng;
 
 // Protobufで定義されたモジュール
 pub mod vector {
-    tonic::include_proto!("vector");
+    tonic::include_proto!("vec");
 }
 
 #[derive(Debug)]

--- a/src/proto/hello.proto
+++ b/src/proto/hello.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package vector;
+package vec;
 
 service VectorService {
   // ベクトルをIDで取得するRPC


### PR DESCRIPTION
# Objective

protoのpackage名とmodの名前を異なると失敗する例を出すため。

cargo runまではできるが、リクエストが失敗することを確認した。
